### PR TITLE
chore: change `l1_server_ip` to `l1_rpc_url` and `l1_beacon_url`

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ once it's done, ssh into the server with `ssh <l2-server-hostname>` and:
 
 after it's up, you can test with:
 ```
-make verify-op-devnet # on the L2 server
+make l2-verify # on the L2 server
 cast block latest --rpc-url http://<l2-server-ip>:9545 # from anywhere
 ```
 
-you can also access the bridge UI at `http://<l2-server-ip>:3002/`
+you can also access the explorer at `http://<l2-server-ip>:3001/` and bridge UI at `http://<l2-server-ip>:3002/`
 
 ## To start Babylon devnet and finality gadget
 

--- a/debian_op_babylon_devnet_l2.yml
+++ b/debian_op_babylon_devnet_l2.yml
@@ -153,11 +153,11 @@
       loop:
         - {
             regexp: "^L1_RPC_URL=.*",
-            replace: "L1_RPC_URL=http://{{ l1_server_ip }}:18545",
+            replace: "L1_RPC_URL={{ l1_rpc_url }}",
           }
         - {
             regexp: "^L1_BEACON_URL=.*",
-            replace: "L1_BEACON_URL=http://{{ l1_server_ip }}:15052",
+            replace: "L1_BEACON_URL={{ l1_beacon_rpc_url }}",
           }
         - {
             regexp: "^L1_CHAIN_ID=.*",

--- a/l2.ini.example
+++ b/l2.ini.example
@@ -3,13 +3,15 @@
 123.456.78.90 ansible_user=satoshi ansible_ssh_private_key_file=/Users/satoshi/.ssh/google_compute_engine
 
 [gcp_vm:vars]
-# l1_server_ip=<L1_SERVER_IP>
-l1_server_ip=34.567.89.12
+# l1_rpc_url=<L1_RPC_URL>
+l1_rpc_url=http://34.567.89.12:8545
+# l1_beacon_rpc_url=<L1_BEACON_RPC_URL>
+l1_beacon_rpc_url=http://34.567.89.12:5052
 # l2_server_ip=<L2_SERVER_IP>
 l2_server_ip=123.456.78.90
-# l1_server_ip=<L1_CHAIN_ID>
+# l1_chain_id=<L1_CHAIN_ID>
 l1_chain_id=70611411
-# l2_server_ip=<L2_CHAIN_ID>
+# l2_chain_id=<L2_CHAIN_ID>
 l2_chain_id=706114
 # bbn_finality_gadget_rpc=<BABYLON_FINALITY_GADGET_RPC>
 bbn_finality_gadget_rpc=http://32.109.87.65:50051


### PR DESCRIPTION
## Summary

This PR updates the `l2.ini` and replaces `l1_server_ip` to `l1_rpc_url` and `l1_beacon_url`.

## Test Plan

update the `l2.ini` with the below L1 info:
```
[gcp_vm:vars]
l1_rpc_url=http://35.202.213.218:18545
l1_beacon_url=http://35.202.213.218:15052
```

and then run and check it:

```
ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i l2.ini debian_op_babylon_devnet_l2.yml

ssh <l2-server>
cd /home/snapchain/op-chain-deployment && sudo chown -R snapchain:snapchain /home/snapchain/op-chain-deployment && make l2-launch

make l2-verify
```


