### PR TITLE
fix: remove schema for fg url

### DIFF
--- a/l2.ini.example
+++ b/l2.ini.example
@@ -14,7 +14,7 @@ l1_chain_id=70611411
 # l2_chain_id=<L2_CHAIN_ID>
 l2_chain_id=706114
 # bbn_finality_gadget_rpc=<BABYLON_FINALITY_GADGET_RPC>
-bbn_finality_gadget_rpc=http://32.109.87.65:50051
+bbn_finality_gadget_rpc=32.109.87.65:50051
 # l1_pre_funded_account_private_key="<L1_PREFUNDED_PRIVATE_KEY>"
 # note: must be filled with double quotes to avoid errors
 l1_pre_funded_account_private_key="0xe169d67d83aef11622914a7c6e0d18e3a5f95f57b76ffc24feda87ace7101083"


### PR DESCRIPTION
## Summary

This is a minor change for the finality gadget URL, the schema `http://` is unnecessary.

## Test Plan

run and then check if the finality gadget url is right in the `.env` file

```
ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i l2.ini debian_op_babylon_devnet_l2.yml
```
